### PR TITLE
Refactor SWD interface to inherit through layers

### DIFF
--- a/Common/Drivers/Interface/SWD/Core/DebugPort.h
+++ b/Common/Drivers/Interface/SWD/Core/DebugPort.h
@@ -3,17 +3,16 @@
 #include "SWD.h"
 
 
-class DebugPort {
+class DebugPort : public SWD {
 private:
-	SWD swd;
-	unsigned int currentAP;
-	unsigned int currentBank;
+        unsigned int currentAP;
+        unsigned int currentBank;
 
 public:
-	DebugPort() {}
+        DebugPort() {}
 
-	DebugPort(AGPIO &clock, AGPIO &data, uint32 frequency) {
-		swd = SWD(clock, data, frequency);
+        DebugPort(AGPIO &clock, AGPIO &data, uint32 frequency) :
+                SWD(clock, data, frequency) {
 
 		// Parse the IDCODE register content
 		uint32_t idCode = getIdCode();
@@ -23,15 +22,15 @@ public:
 		}
 
 		// Clear any errors
-		swd.write(false, 0, 0x1e);
+                write(false, 0, 0x1e);
 
 		// Get the SELECT register to a known state
 		currentAP = 0;
 		currentBank = 0;
-		swd.write(false, 2, 0);
+                write(false, 2, 0);
 
 		// Enable power
-		swd.write(false, 1, 0x54000000);
+                write(false, 1, 0x54000000);
 		if ((getStatus() >> 24) != 0xF4) {
 			// TODO: runtime_error
 			//throw std::runtime_error("Could not enable power.");
@@ -43,7 +42,7 @@ public:
 
 
 	uint32_t getIdCode() {
-		return swd.read(false, 0);
+                return read(false, 0);
 	}
 
 
@@ -51,7 +50,7 @@ public:
 
 
 	uint32_t getStatus() {
-		return swd.read(false, 1);
+                return read(false, 1);
 	}
 
 
@@ -62,7 +61,7 @@ public:
 		if (apSel == currentAP && apBank == currentBank) {
 			return;
 		}
-		swd.write(false, 2, ((apSel & 0xff) << 24) || ((apBank & 0xf) << 4));
+                write(false, 2, ((apSel & 0xff) << 24) || ((apBank & 0xf) << 4));
 		currentAP = apSel;
 		currentBank = apBank;
 	}
@@ -72,7 +71,7 @@ public:
 
 
 	uint32_t readRB() {
-		return swd.read(false, 3);
+                return read(false, 3);
 	}
 
 
@@ -83,7 +82,7 @@ public:
 		unsigned int bank = address >> 4;
 		unsigned int reg = (address >> 2) & 0x3;
 		select(apSel, bank);
-		return swd.read(true, reg);
+                return read(true, reg);
 	}
 
 
@@ -94,7 +93,7 @@ public:
 		unsigned int bank = address >> 4;
 		unsigned int reg = (address >> 2) & 0x3;
 		select(apSel, bank);
-		swd.write(true, reg, value);
+                write(true, reg, value);
 	}
 };
 

--- a/Common/Drivers/Interface/SWD/Core/MemoryAccessPort.h
+++ b/Common/Drivers/Interface/SWD/Core/MemoryAccessPort.h
@@ -3,27 +3,27 @@
 #include "DebugPort.h"
 
 
-class MemoryAccessPort {
+class MemoryAccessPort : public DebugPort {
 private:
-	DebugPort debugPort;
-	uint32 apSel;
+        uint32 apSel;
 
 
 public:
-	MemoryAccessPort() {}
+        MemoryAccessPort() {}
 
-	MemoryAccessPort(AGPIO &clock, AGPIO &data, uint32 frequency, uint32 apSel): apSel(apSel) {
-		debugPort = DebugPort(clock, data, frequency);
-		csw(1, 2);
-	}
+        MemoryAccessPort(AGPIO &clock, AGPIO &data, uint32 frequency, uint32 apSel) :
+                DebugPort(clock, data, frequency),
+                apSel(apSel) {
+                csw(1, 2);
+        }
 
 
 
 
 
 	uint32_t getIdCode() {
-		debugPort.readAP(apSel, 0xfc);
-		return debugPort.readRB();
+                readAP(apSel, 0xfc);
+                return readRB();
 	}
 
 
@@ -31,9 +31,9 @@ public:
 
 
 	uint32_t readWord(uint32_t address) {
-		debugPort.writeAP(apSel, 0x04, address);
-		debugPort.readAP(apSel, 0x0c);
-		return debugPort.readRB();
+                writeAP(apSel, 0x04, address);
+                readAP(apSel, 0x0c);
+                return readRB();
 	}
 
 
@@ -41,9 +41,9 @@ public:
 
 
 	uint32_t writeWord(uint32_t address, uint32_t value) {
-		debugPort.writeAP(apSel, 0x04, address);
-		debugPort.writeAP(apSel, 0x0c, value);
-		return debugPort.readRB();
+                writeAP(apSel, 0x04, address);
+                writeAP(apSel, 0x0c, value);
+                return readRB();
 	}
 
 
@@ -52,10 +52,10 @@ public:
 
 	uint32_t readHalf(uint32_t address) {
 		csw(0, 1);
-		debugPort.writeAP(apSel, 0x04, address);
-		debugPort.readAP(apSel, 0x0c);
-		csw(1, 2);
-		return debugPort.readRB();
+                writeAP(apSel, 0x04, address);
+                readAP(apSel, 0x0c);
+                csw(1, 2);
+                return readRB();
 	}
 
 
@@ -64,11 +64,11 @@ public:
 
 	uint32_t writeHalf(uint32_t address, uint32_t value) {
 		csw(1, 1);
-		debugPort.writeAP(apSel, 0x04, address);
-		debugPort.writeAP(apSel, 0x0c, value);
-		debugPort.writeAP(apSel, 0x0c, value);
-		csw(1, 2);
-		return debugPort.readRB();
+                writeAP(apSel, 0x04, address);
+                writeAP(apSel, 0x0c, value);
+                writeAP(apSel, 0x0c, value);
+                csw(1, 2);
+                return readRB();
 	}
 
 
@@ -76,12 +76,12 @@ public:
 
 
 	void readBlock(uint32_t address,  uint32_t count, uint32_t *buffer) {
-		debugPort.writeAP(apSel, 0x04, address);
-		debugPort.readAP(apSel, 0x0c);
+                writeAP(apSel, 0x04, address);
+                readAP(apSel, 0x0c);
 		for (unsigned int i = 0; i < count - 1; i++) {
-			buffer[i] = debugPort.readAP(apSel, 0x0c);
+                        buffer[i] = readAP(apSel, 0x0c);
 		}
-		buffer[count - 1] = debugPort.readRB();
+                buffer[count - 1] = readRB();
 	}
 
 
@@ -89,9 +89,9 @@ public:
 
 
 	void writeBlock(uint32_t address, uint32_t count, const uint32_t *buffer) {
-		debugPort.writeAP(apSel, 0x04, address);
+                writeAP(apSel, 0x04, address);
 		for (unsigned int i = 0; i < count; i++) {
-			debugPort.writeAP(apSel, 0x0c, buffer[i]);
+                        writeAP(apSel, 0x0c, buffer[i]);
 		}
 	}
 
@@ -114,10 +114,10 @@ public:
 	void writeHalfs(uint32_t address, uint32_t count, const uint32_t *buffer) {
 		// 16-bit auto-incrementing addressing
 		csw(1, 1);
-		debugPort.writeAP(apSel, 0x04, address);
+                writeAP(apSel, 0x04, address);
 		for (unsigned int i = 0; i < count; i++) {
-			debugPort.writeAP(apSel, 0x0c, buffer[i]);
-			debugPort.writeAP(apSel, 0x0c, buffer[i]);
+                        writeAP(apSel, 0x0c, buffer[i]);
+                        writeAP(apSel, 0x0c, buffer[i]);
 		}
 		/*// 16-bit packed-incrementing addressing
 		csw(2, 1);
@@ -129,9 +129,9 @@ public:
 
 private:
 	void csw(unsigned int addrInc, unsigned int size) {
-		debugPort.readAP(apSel, 0x00);
-		uint32_t csw = debugPort.readRB() & 0xFFFFFF00;
-		debugPort.writeAP(apSel, 0x00, csw + (addrInc << 4) + size);
+                readAP(apSel, 0x00);
+                uint32_t csw = readRB() & 0xFFFFFF00;
+                writeAP(apSel, 0x00, csw + (addrInc << 4) + size);
 	}
 
 };

--- a/Common/Drivers/Interface/SWD/STM32.h
+++ b/Common/Drivers/Interface/SWD/STM32.h
@@ -4,7 +4,7 @@
 
 
 // STM32 -> MemoryAccessPort -> DebugPort -> SWD
-class STM32 {
+class STM32 : public MemoryAccessPort {
 	static const uint32 FLASH_BASE_REGION = 0x40022000;
 
 	static const uint32 FLASH_KEYR = FLASH_BASE_REGION + 0x04;
@@ -13,60 +13,56 @@ class STM32 {
 	static const uint32 FLASH_AR = FLASH_BASE_REGION + 0x14;
 
 
-private:
-	MemoryAccessPort memoryAccessPort;
-
-
 public:
-	STM32(AGPIO &clock, AGPIO &data, uint32 frequency, uint32 apSel) {
-		memoryAccessPort = MemoryAccessPort(clock, data, frequency, apSel);
-	}
+        STM32(AGPIO &clock, AGPIO &data, uint32 frequency, uint32 apSel) :
+                MemoryAccessPort(clock, data, frequency, apSel) {
+        }
 
 
 	void halt() {
-		memoryAccessPort.writeWord(0xE000EDF0, 0xA05F0003);
+                writeWord(0xE000EDF0, 0xA05F0003);
 	}
 
 
 	void unhalt() {
-		memoryAccessPort.writeWord(0xE000EDF0, 0xA05F0000);
+                writeWord(0xE000EDF0, 0xA05F0000);
 	}
 
 
 	void reset() {
-		memoryAccessPort.writeWord(0xE000ED0C, 0x05FA0004);
+                writeWord(0xE000ED0C, 0x05FA0004);
 	}
 
 
 	void unlockFlash() {
-		memoryAccessPort.writeWord(FLASH_KEYR, 0x45670123);
-		memoryAccessPort.writeWord(FLASH_KEYR, 0xcdef89ab);
+                writeWord(FLASH_KEYR, 0x45670123);
+                writeWord(FLASH_KEYR, 0xcdef89ab);
 	}
 
 
 	void lockFlash() {
-		memoryAccessPort.writeWord(FLASH_CR, memoryAccessPort.readWord(FLASH_CR) | (1 << 7));
+                writeWord(FLASH_CR, readWord(FLASH_CR) | (1 << 7));
 	}
 
 
 	void startProgramming() {
-		memoryAccessPort.writeWord(FLASH_CR, 1);
+                writeWord(FLASH_CR, 1);
 	}
 
 
 	void endProgramming() {
-		memoryAccessPort.writeWord(FLASH_CR, 0);
+                writeWord(FLASH_CR, 0);
 	}
 
 
 	void eraseFlash(uint32_t page) {
-		memoryAccessPort.writeWord(FLASH_CR, 2);
-		memoryAccessPort.writeWord(FLASH_AR, page);
-		memoryAccessPort.writeWord(FLASH_CR, 0x42);
-		while ((memoryAccessPort.readWord(FLASH_SR) & 0x1) != 0) {
-			System::DelayUs(10000);
-		}
-	}
+                writeWord(FLASH_CR, 2);
+                writeWord(FLASH_AR, page);
+                writeWord(FLASH_CR, 0x42);
+                while ((readWord(FLASH_SR) & 0x1) != 0) {
+                        System::DelayUs(10000);
+                }
+        }
 
 
 	void eraseFlash() {
@@ -75,14 +71,14 @@ public:
 
 
 	void waitFlash() {
-		while ((memoryAccessPort.readWord(FLASH_SR) & 0x1) != 0) {
-			System::DelayUs(10000);
-		}
-	}
+                while ((readWord(FLASH_SR) & 0x1) != 0) {
+                        System::DelayUs(10000);
+                }
+        }
 
 
 	MemoryAccessPort *getMemoryAccessPort() {
-		return &memoryAccessPort;
+                return this;
 	}
 
 };


### PR DESCRIPTION
## Summary
- refactor SWD driver hierarchy to use inheritance instead of composition
- update DebugPort, MemoryAccessPort and STM32 classes accordingly

## Testing
- `git status --short`