### PR TITLE
Remove unintended delays in the SPI driver to fix errors in the Bluetooth stack startup routine.

### DIFF
--- a/Periphery/Adapter/Port/F4/SPIAdapterF4.h
+++ b/Periphery/Adapter/Port/F4/SPIAdapterF4.h
@@ -157,6 +157,9 @@ protected:
 
 		LL_SPI_SetStandard(spiHandle, LL_SPI_PROTOCOL_MOTOROLA);
 
+		// Enable SPI once during initialization
+		LL_SPI_Enable(spiHandle);
+
 		return BeforeInitialization();
 	}
 
@@ -211,9 +214,7 @@ protected:
 		LL_SPI_EnableIT_RXNE(spiHandle);
 		LL_SPI_EnableIT_ERR(spiHandle);
 
-		if(!LL_SPI_IsEnabled(spiHandle)) {
-			LL_SPI_Enable(spiHandle);
-		}
+		// SPI is already enabled during initialization
 
 		return Status::ok;
 	}
@@ -242,9 +243,7 @@ protected:
 		uint32 tickStart = System::GetTick();
 
 
-		if(!LL_SPI_IsEnabled(spiHandle)) {
-			LL_SPI_Enable(spiHandle);
-		}
+		// SPI is already enabled during initialization
 
 
 		if (parameters.mode == Mode::Slave || size == 1) {
@@ -256,7 +255,7 @@ protected:
 		for (; txDataCounter < txDataNeed; txDataCounter++) {
 			while(!LL_SPI_IsActiveFlag_TXE(spiHandle)) {
 				if((System::GetTick() - tickStart) > timeout) {
-					LL_SPI_Disable(spiHandle);
+					// Keep SPI enabled even on timeout
 					txState = Status::ready;
 					return Status::timeout;
 				}
@@ -270,7 +269,7 @@ protected:
 			LL_SPI_ClearFlag_OVR(spiHandle);
 		}
 
-		LL_SPI_Disable(spiHandle);
+		// Keep SPI enabled between transfers
 		txState = Status::ready;
 
 		return Status::ok;
@@ -291,15 +290,13 @@ protected:
 		uint32 tickStart = System::GetTick();
 
 
-		if(!LL_SPI_IsEnabled(spiHandle)) {
-			LL_SPI_Enable(spiHandle);
-		}
+		// SPI is already enabled during initialization
 
 
 		for (rxDataCounter = 0; rxDataCounter < rxDataNeed; rxDataCounter++) {
 			while(!LL_SPI_IsActiveFlag_RXNE(spiHandle)) {
 				if((System::GetTick() - tickStart) > timeout) {
-					LL_SPI_Disable(spiHandle);
+					// Keep SPI enabled even on timeout
 					rxState = Status::ready;
 					return Status::timeout;
 				}
@@ -310,7 +307,7 @@ protected:
 		}
 
 
-		LL_SPI_Disable(spiHandle);
+		// Keep SPI enabled between transfers
 		rxState = Status::ready;
 
 		return Status::ok;
@@ -337,9 +334,7 @@ protected:
 		uint32 tickStart = System::GetTick();
 
 
-		if(!LL_SPI_IsEnabled(spiHandle)) {
-			LL_SPI_Enable(spiHandle);
-		}
+		// SPI is already enabled during initialization
 
 
 		if (parameters.mode == Mode::Slave || size == 1) {
@@ -365,7 +360,7 @@ protected:
 			}
 
 			if((System::GetTick() - tickStart) > timeout) {
-				LL_SPI_Disable(spiHandle);
+				// Keep SPI enabled even on timeout
 				txState = Status::ready;
 				rxState = Status::ready;
 				return Status::timeout;
@@ -377,7 +372,7 @@ protected:
 			LL_SPI_ClearFlag_OVR(spiHandle);
 		}
 
-		LL_SPI_Disable(spiHandle);
+		// Keep SPI enabled between transfers
 
 		txState = Status::ready;
 		rxState = Status::ready;
@@ -402,9 +397,7 @@ protected:
 		LL_SPI_EnableIT_TXE(spiHandle);
 		LL_SPI_EnableIT_ERR(spiHandle);
 
-		if(!LL_SPI_IsEnabled(spiHandle)) {
-			LL_SPI_Enable(spiHandle);
-		}
+		// SPI is already enabled during initialization
 
 		return Status::ok;
 	}


### PR DESCRIPTION
MainControl v1.4.0 PCBs were having intermittent Bluetooth stack start up failures at a rate of about 60%. This came after the nRF8001 BT IC was physically moved closer to the MCU on the PCB.

Through a variety of troubleshooting methods, Claude Code and I identified that SPIAdapterF4.h was set up to disable the SPI after each communication, which released the SPI peripheral from the corresponding pins. This is not standard practice according to Claude Code. Convention is to leave the SPI peripheral enabled unless the pins specifically need to used for something else or we are trying to optimize for power during sleep state - neither of which are applicable to our use case. 

We believe the timing delays related to having to re-enable the SPI bus prior to each communication in addition to the physical changes to the SPI communication trace lengths were causing SPI communication errors which were preventing the nRF8001 from successfully completing the Bluetooth stack startup routine. The nRF8001 did not receive valid setup instructions, so the chip remained in 'setup mode' and the MCU did not have a method to check the state of the BT chip and recover from it not completing the setup routine.

Claude Code removed the statements that disabled the SPI bus and with this change, all 10/10 boards reliably completed the BT setup sequence and started advertising.